### PR TITLE
Add conda environment.yml file for easier dependency installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ dependencies:
   - python=3.9
   - cartopy
   - cmocean
+  - jupyter
+  - jupyterlab
   - matplotlib
   - netCDF4
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: coastwatch
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - cartopy
+  - cmocean
+  - matplotlib
+  - netCDF4
+  - pandas
+  - pyproj 
+  - requests
+  - shapely
+  - statsmodels
+  - xarray


### PR DESCRIPTION
Running the following with Conda installed should provide all the required dependencies - Python version used: 3.9:

```
conda env create -f environment.yml
conda activate coastwatch
``` 